### PR TITLE
Allow other solution names for DeployOnly

### DIFF
--- a/workflow-templates/DataMiner-CICD-Automation-DeployOnly.yml
+++ b/workflow-templates/DataMiner-CICD-Automation-DeployOnly.yml
@@ -24,6 +24,12 @@ jobs:
     steps:
        - uses: actions/checkout@v3
 
+       - name: Find .sln file
+         id: findSlnFile 
+         run: |
+           echo solutionFilePath=$(find . -type f -name '*.sln') >> $GITHUB_OUTPUT
+         shell: bash
+
        - name: Skyline DataMiner Deploy Action Development
          if: github.ref_type == 'branch'
          uses: SkylineCommunications/Skyline-DataMiner-Deploy-Action@v1
@@ -32,7 +38,7 @@ jobs:
            stage: All
            # The API-key: generated in the DCP Admin app (https://admin.dataminer.services/) as authentication for a certain DataMiner System.
            api-key: ${{ secrets.DATAMINER_DEPLOY_KEY }}
-           solution-path: ./AutomationScript.sln
+           solution-path: ./${{ steps.findSlnFile.outputs.solutionFilePath }}
            artifact-name: ${{ github.repository }} ${{ github.ref_name }}_B${{ github.run_number }}
            build-number: ${{ github.run_number }}
            
@@ -44,7 +50,7 @@ jobs:
            stage: All
            # The API-key: generated in the DCP Admin app (https://admin.dataminer.services/) as authentication for a certain DataMiner System.
            api-key: ${{ secrets.DATAMINER_DEPLOY_KEY }}
-           solution-path: ./AutomationScript.sln
+           solution-path: ./${{ steps.findSlnFile.outputs.solutionFilePath }}
            artifact-name: ${{ github.repository }} ${{ github.ref_name }}
            version: ${{ github.ref_name }}
            


### PR DESCRIPTION
DeployOnly was still hardcoded to AutomationScript.sln.
The new Visual Studio templates allow any name.